### PR TITLE
adds pages controller for about page

### DIFF
--- a/app/assets/javascripts/pages.coffee
+++ b/app/assets/javascripts/pages.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Pages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def about
+    @about = 'About This App'
+  end
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,2 @@
+<h1>About Page</h1>
+<p><%= @about %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  get 'about' => 'pages#about'
   root 'posts#index'
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Generates a pages controller to show an about page. In Terminal, run
**`rails g controller Pages`**
Add a method to the pages_controller called _about_. In that method, set up an instance variable to pass a message to that view. 
In the new view directory, create a view for this page, _about.html.erb_. Add the instance variable as embedded Ruby with the =
Route the url to that page. Open routes and add this line above the root:
**get 'about' => 'pages#about'**
The syntax for this get request route is _get 'what to show in the url' => 'controller#method'_