### PR TITLE
adds a foundation panel for each post

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -11,3 +11,9 @@ div.callout {
 div.callout.alert {
   color: #a94442
 }
+
+// style the foundation card class
+div.card {
+  background: #e6e6e6;
+  border-radius: 6px;
+}

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,10 @@
 <h1 class='text-center'>Home Page</h1>
 <% @posts.each do |post| %>
-  <h2><%= post.title %></h2>
-  <p><%= post.body %></p>
-  <hr>
+  <div class="card">
+    <div class="card-section">
+      <h2><%= post.title %></h2>
+      <p><%= post.body %></p>
+      <%= link_to "Show Post", post_path(post), :class => 'button primary' %>
+    </div>
+  </div>
 <% end %>


### PR DESCRIPTION
This uses the foundation class `.card` and also `.card-section` to achieve the look of a bootstrap well. Each post has its own container. By default, there is no styling applied to this. The CSS for this was updated to have the same grey color as the navbar, #e6e6e6. Also rounded the edges to 6px.
The `.card` is the parent class in the div which will contain each post. Inside this, use a class of `.card-section` around the actual content. 