### PR TITLE
adds edit post feature

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,6 +27,24 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  # this method will allow post editing
+  def edit
+    @post = Post.find(params[:id])
+  end
+
+  # method to save updates to a post once it has been edited
+  def update
+    @post = Post.find(params[:id])
+    # update a post and bring in previous post values
+    if(@post.update(post_params))
+      # show the edited post after it's successfully updated
+      redirect_to @post
+    else
+      # if form validations do not pass, render the edit view again
+      render 'edit'
+    end
+  end
+
   private
   def post_params
     params.require(:post).permit(:title, :body)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,29 @@
+<h1>Edit Post</h1>
+<!-- set url for the form to submit to an edit path from the post controller on click -->
+<%= form_for :post, url: post_path(@post), method: :patch do |f| %>
+  <!-- form validation error messages -->
+  <% if @post.errors.any? %>
+    <% @post.errors.full_messages.each do |msg| %>
+      <div data-closable class="callout alert">
+        <button class="close-button" aria-label="Close alert" type="button" data-close>
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <%= msg %>
+      </div>
+    <% end %>
+  <% end %>
+  <p>
+    <%= f.label :title %><br>
+    <%= f.text_field :title %>
+  </p>
+
+  <p>
+    <%= f.label :body %><br>
+    <%= f.text_area :body %>
+  </p>
+
+  <p>
+    <%= f.submit 'Edit Post', ({:class => 'button'}) %>
+  </p>
+
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
     <div class="card-section">
       <h2><%= post.title %></h2>
       <p><%= post.body %></p>
-      <%= link_to "Show Post", post_path(post), :class => 'button primary' %>
+      <%= link_to 'Show Post', post_path(post), :class => 'button primary' %>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,2 +1,4 @@
 <h2><%= @post.title %></h2>
 <p><%= @post.body %></p>
+<hr>
+<%= link_to 'Edit Post', edit_post_path(@post), :class => 'button'%>


### PR DESCRIPTION
This feature required the posts_controller to have two additional methods: `edit` and `update`.
In the edit method, it is enough to just get the post to be edited. Do that by adding 
`@post = Post.find(params[:id])` to the edit method.
Also need to create an edit view, which looks similar to the new view but has some differences in the form_for helper. Since _a post_ is being updated, use 
`<%= form_for :post, url: post_path(@post), method: :patch do |f| %>`
The edit view also has updated text to indicate which page a user is on. Otherwise, it's structured the same as the new view. 
In the posts_controller, need to have a method for updating a post after it's edited. This looks similar to the create method but has some differences:
```
def update
    @post = Post.find(params[:id])
    # update a post and bring in previous post values
    if(@post.update(post_params))
      # show the edited post after it's successfully updated
      redirect_to @post
    else
      # if form validations do not pass, render the edit view again
      render 'edit'
    end
  end
```