### PR TITLE
adds delete feature for posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
-  # this method will allow post editing
+  # this method will bring in post values and allow editing
   def edit
     @post = Post.find(params[:id])
   end
@@ -43,6 +43,13 @@ class PostsController < ApplicationController
       # if form validations do not pass, render the edit view again
       render 'edit'
     end
+  end
+
+  # method to delete a post
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to posts_path
   end
 
   private

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,3 +2,7 @@
 <p><%= @post.body %></p>
 <hr>
 <%= link_to 'Edit Post', edit_post_path(@post), :class => 'button'%>
+<%= link_to 'Delete Post', post_path(@post),
+    method: :delete,
+    data: {confirm: 'Delete this post?'},
+    :class => 'button alert' %>


### PR DESCRIPTION
Adding delete feature to posts. The delete button is styled using foundation's alert class. The controller needs a method called destroy:
```
def destroy
    @post = Post.find(params[:id])
    @post.destroy
    redirect_to posts_path
  end
```
In the show view, the button to delete posts is next to the edit button. For now, anyone can delete posts which is not good. but that will be addressed in a later update. Delete button in the show view:
```
<%= link_to 'Delete Post', post_path(@post),
    method: :delete,
    data: {confirm: 'Delete this post?'},
    :class => 'button alert' %>
```