### PR TITLE
adds comment feature

### DIFF
--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,18 @@
+class CommentsController < ApplicationController
+  # create a new comment for a post
+  def create
+    # find the post for which to create a comment. use :post_id
+    @post = Post.find(params[:post_id])
+    # create a comment
+    @comment = @post.comments.create(comment_params)
+    # redirect to the same page of the post
+    redirect_to post_path(@post)
+  end
+
+  private
+
+  # strong parameters for comments
+  def comment_params
+    params.require(:comment).permit(:username, :body)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -52,6 +52,7 @@ class PostsController < ApplicationController
     redirect_to posts_path
   end
 
+  # strong parameters for posts
   private
   def post_params
     params.require(:post).permit(:title, :body)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  # a comment belongs to a post, set the relationship here and in the post model
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  # a post can have many comments, link comments and posts here
+  has_many :comments
   # sets form validation conditions for post titles
   validates :title, presence: true, length: {minimum: 3}
   # sets form validation conditions for posts

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,3 +6,35 @@
     method: :delete,
     data: {confirm: 'Delete this post?'},
     :class => 'button alert' %>
+<!-- show all comments to a post -->
+<h3>Comments</h3>
+<!-- since there may be many comments, loop through them to show all -->
+<% @post.comments.each do |comment| %>
+  <div class="card">
+    <div class="card-section">
+      <p>
+        <strong><%= comment.username %></strong>:
+        <%= comment.body %>
+      </p>
+    </div>
+  </div>
+<% end %>
+<hr>
+
+<!-- add comment form -->
+<h3>Add Comment</h3>
+<%= form_for([@post, @post.comments.build]) do |f| %>
+  <p>
+    <%= f.label :username %><br>
+    <%= f.text_field :username %>
+  </p>
+
+  <p>
+    <%= f.label :body %><br>
+    <%= f.text_area :body %>
+  </p>
+
+  <p>
+    <%= f.submit 'Create Comment', ({:class => 'button secondary'}) %>
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@ Rails.application.routes.draw do
   # /about will show in url, maps to pages controller, about method
   get 'about' => 'pages#about', as: 'about'
   # setting the posts as a resource enables crud routes for the posts controller
-  resources :posts
+  resources :posts do
+    # nest the comments to a post inside the post resources routes
+    resources :comments
+  end
   # route to landing page where all posts will be
   root 'posts#index', as: 'home'
 end

--- a/db/migrate/20190518011545_create_comments.rb
+++ b/db/migrate/20190518011545_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.string :username
+      t.text :body
+      t.references :post, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_171655) do
+ActiveRecord::Schema.define(version: 2019_05_18_011545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.string "username"
+    t.text "body"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
@@ -22,4 +31,5 @@ ActiveRecord::Schema.define(version: 2019_05_16_171655) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "comments", "posts"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  username: MyString
+  body: MyText
+  post: one
+
+two:
+  username: MyString
+  body: MyText
+  post: two

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This update requires a new model and controller to be generated. It also needs a has_many and belongs_to relationship in the models:
`rails g model Comment username body:text post:references`
Post:references means a comment will refer to a specific post. In the new Comment model, there will be a line for belongs_to :post.
Also need to add in the Post model a line at the top 
`has_many :comments` since a post can have multiple comments. 
This also needed a new comments controller, a new route for comments associated with posts, and new forms to submit comments on the show view. 
The routes were updated to be
```
resources :posts do
    # nest the comments to a post inside the post resources routes
    resources :comments
end
```