### PR TITLE
delete comment feature added

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -17,3 +17,12 @@ div.card {
   background: #e6e6e6;
   border-radius: 6px;
 }
+
+// style the close X for deleting comments
+a.close {
+  background: #f7e4e1;
+  color: #a94442;
+  padding: 3px 5px 5px 5px;
+  margin-left: 10px;
+  border: 1px solid #a94442;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,6 +9,18 @@ class CommentsController < ApplicationController
     redirect_to post_path(@post)
   end
 
+  # destroy method to delete a comment
+  def destroy
+    # find the post for which to delete a comment. use :post_id
+    @post = Post.find(params[:post_id])
+    # find the comment for a post
+    @comment = @post.comments.find(params[:id])
+    # delete the comment for a post
+    @comment.destroy
+    # redirect to the same page of the post
+    redirect_to post_path(@post)
+  end
+
   private
 
   # strong parameters for comments

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,18 @@
+<!-- show all comments to a post -->
+<h3>Comments</h3>
+<!-- since there may be many comments, loop through to show all -->
+<% @post.comments.each do |comment| %>
+  <div class="card">
+    <div class="card-section">
+      <p>
+        <strong><%= comment.username %></strong>:
+        <%= comment.body %>
+        <!-- delete a comment link -->
+        <%= link_to '&times;'.html_safe, [comment.post, comment],
+        class: 'close',
+        method: :delete,
+        data: {confirm: 'Delete Comment?'} %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,17 @@
+<!-- add comment form -->
+<h3>Add Comment</h3>
+<%= form_for([@post, @post.comments.build]) do |f| %>
+  <p>
+    <%= f.label :username %><br>
+    <%= f.text_field :username %>
+  </p>
+
+  <p>
+    <%= f.label :body %><br>
+    <%= f.text_area :body %>
+  </p>
+
+  <p>
+    <%= f.submit 'Create Comment', ({:class => 'button secondary'}) %>
+  </p>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,35 +6,9 @@
     method: :delete,
     data: {confirm: 'Delete this post?'},
     :class => 'button alert' %>
-<!-- show all comments to a post -->
-<h3>Comments</h3>
-<!-- since there may be many comments, loop through them to show all -->
-<% @post.comments.each do |comment| %>
-  <div class="card">
-    <div class="card-section">
-      <p>
-        <strong><%= comment.username %></strong>:
-        <%= comment.body %>
-      </p>
-    </div>
-  </div>
-<% end %>
 <hr>
 
-<!-- add comment form -->
-<h3>Add Comment</h3>
-<%= form_for([@post, @post.comments.build]) do |f| %>
-  <p>
-    <%= f.label :username %><br>
-    <%= f.text_field :username %>
-  </p>
-
-  <p>
-    <%= f.label :body %><br>
-    <%= f.text_area :body %>
-  </p>
-
-  <p>
-    <%= f.submit 'Create Comment', ({:class => 'button secondary'}) %>
-  </p>
-<% end %>
+<!-- comment partial in the comment folder to show all comments -->
+<%= render 'comments/comment' %>
+<!-- form partial in the comment folder to create a comment -->
+<%= render 'comments/form' %>


### PR DESCRIPTION
This feature allows comments to be deleted. It also separates comment forms and viewing comments into partials. 
Basic styling for &times; was applied for deleting comments. 
The destroy method in the comments controller:
```
def destroy
    # find the post for which to delete a comment. use :post_id
    @post = Post.find(params[:post_id])
    # find the comment for a post
    @comment = @post.comments.find(params[:id])
    # delete the comment for a post
    @comment.destroy
    # redirect to the same page of the post
    redirect_to post_path(@post)
end
```